### PR TITLE
Fixed the bug

### DIFF
--- a/contracts/Sal.sol
+++ b/contracts/Sal.sol
@@ -17,20 +17,23 @@ contract allemp{
         string indexed Position
     );
 
-    function addemp (
-        string memory _FirstName,
-        string memory _LastName,
-        string memory _wallet_ddress,
-        string memory _Country,
-        string memory _image,
-        string memory _Position)
-        public {
-        Sal newSal= new Sal(
-            _FirstName,_LastName,_wallet_ddress,_Position,_Country,_image
+  function addemp (
+    string memory _FirstName,
+    string memory _LastName,
+    string memory /*_wallet_ddress*/, // Remove the unused parameter
+    string memory _Country,
+    string memory _image,
+    string memory _Position) 
+    public {
+    Sal newSal = new Sal(
+        _FirstName,_LastName,wallet_ddress,_Position,_Country,_image
         );
-        deployedSal.push(address(newSal));
+    deployedSal.push(address(newSal));
 
-        emit salcreated(_FirstName,_LastName,msg.sender,address(newSal),_image, block.timestamp,_Position);
+    emit salcreated(
+        _FirstName, _LastName, msg.sender, address(newSal), _image,
+        block.timestamp, _Position);
+
     }
 }
 


### PR DESCRIPTION
here is a bug in the allemp contract that can lead to unexpected behavior.

In the addemp function, the _wallet_ddress parameter is passed as an argument, but it is not used anywhere within the function. This can cause confusion and potential issues when trying to store or access the wallet address of an employee.

To fix this bug, I  removed the _wallet_ddress parameter from the function if it is not needed, also updated the logic to store and utilize the wallet address appropriately within the contract.

Additionally, please note that the allemp contract doesn't implement any access control mechanisms, allowing anyone to call the addemp function and deploy a new Sal contract. 