### PR TITLE
Added owner check for `donate` function

### DIFF
--- a/contracts/Sal.sol
+++ b/contracts/Sal.sol
@@ -70,6 +70,7 @@ contract Sal{
     }
 
     function donate () public payable {
+    require(msg.sender==owner,"You are not the owner!");
         owner.transfer(msg.value);
         recievedamnt+=msg.value;
 


### PR DESCRIPTION
Added a check to verify if msg.sender is owner or not in [sal.sol](https://github.com/Vikash-8090-Yadav/SaL--dApp/blob/7c36600c0642178286d33d443eec270b67e0a322/contracts/Sal.sol#L72)
fixes issue #80 