### PR TITLE
Prevent Duplicate Employee Entries in addemp function 

### DIFF
--- a/contracts/Sal.sol
+++ b/contracts/Sal.sol
@@ -6,6 +6,7 @@ pragma solidity >0.7.0 <=0.9.0;
 contract allemp{
 
     address [] public deployedSal;
+    mapping(string => bool) public isEmployeeRegistered; // New mapping to check duplicate employees
 
     event salcreated(
         string FirstName,
@@ -20,17 +21,22 @@ contract allemp{
     function addemp (
         string memory _FirstName,
         string memory _LastName,
-        string memory _wallet_ddress,
+        string memory _wallet_address,
         string memory _Country,
         string memory _image,
         string memory _Position)
         public {
-        Sal newSal= new Sal(
-            _FirstName,_LastName,_wallet_ddress,_Position,_Country,_image
-        );
-        deployedSal.push(address(newSal));
 
-        emit salcreated(_FirstName,_LastName,msg.sender,address(newSal),_image, block.timestamp,_Position);
+      require(!isEmployeeRegistered[_wallet_address], "Employee already registered"); // Check if employee is already registered
+
+        Sal newSal= new Sal(_FirstName,_LastName,_wallet_address,_Position,_Country,_image);
+        deployedSal.push(address(newSal));
+        
+         isEmployeeRegistered[_wallet_address] = true; // Mark employee as registered
+
+        emit salcreated(_FirstName,_LastName,msg.sender,address(newSal),_image, block.timestamp,_Position);      
+
+      
     }
 }
 
@@ -52,7 +58,7 @@ contract Sal{
     constructor(
         string memory _FirstName,
         string memory _LastName,
-        string memory _wallet_ddress,
+        string memory _wallet_address,
         string memory _Position,
         string memory _Country,
         string memory _image
@@ -60,7 +66,7 @@ contract Sal{
     {
         FirstName = _FirstName;
         LastName = _LastName;
-        wallet_address = _wallet_ddress;
+        wallet_address = _wallet_address;
         Position =_Position;
         Country =_Country;
         image = _image;


### PR DESCRIPTION
issue #92 


I encountered an issue in the addemp function of the allemp contract, where duplicate employee entries are not being prevented. After investigating the code, I found that the function lacks a check for existing employees, resulting in duplicate entries.

To address this issue, I propose implementing a "require" condition in the addemp function. This condition will check if the employee already exists and revert the transaction to prevent duplicate entries. This solution will enhance the efficiency of the contract by avoiding unnecessary gas fees.
#92 